### PR TITLE
Add convergence tracker failure on timeout

### DIFF
--- a/kube-burner-workload/README.md
+++ b/kube-burner-workload/README.md
@@ -354,7 +354,7 @@ before deleting the workload.
 
 ## Running
 
-1. Install kube-burner v1.9.0+
+1. Install kube-burner v1.9.4+
   
     1.1 You can download kube-burner from https://github.com/cloud-bulldozer/kube-burner/releases
     

--- a/kube-burner-workload/README.md
+++ b/kube-burner-workload/README.md
@@ -333,6 +333,13 @@ and also may be reused and improved by the same platform as a part of this frame
 
 Every platform may have its own README.
 
+### Comparing different platforms
+
+To ensure results for different platform are comparable, set up the convergence tracker logic to be as similar as possible,
+all timeouts and variables defining successful test run should be the same.
+Cluster-specific parameters, like resource quotas, enables services (e.g. observability), nodes configurations may also
+affect the results.
+
 ## Tracking the end of the test
 
 `CONVERGENCE_TRACKER` env variable enables `convergence-tracker` job.

--- a/kube-burner-workload/convergence_waiter.sh
+++ b/kube-burner-workload/convergence_waiter.sh
@@ -3,9 +3,14 @@
 TIME_SPENT=0
 TIMEOUT=$((CONVERGENCE_TIMEOUT + CONVERGENCE_PERIOD))
 while [ $TIME_SPENT -le "$TIMEOUT" ]; do
-  # failure will return 1 because of the "echo FAILED| wc -l"
-  PODS_COUNT=$( (kubectl get pods -n convergence-tracker-0 --no-headers || echo FAILED) | grep -c -v Completed)
-  if [ "$PODS_COUNT" -eq 0 ]; then
+  FAILED_COUNT=$(kubectl get pods -n convergence-tracker-0 --field-selector status.phase=Failed -o name | wc -l)
+  if [ "$FAILED_COUNT" -ne 0 ]; then
+    echo "ERROR: convergence tracker pod reported failure"
+    kubectl get pods -n convergence-tracker-0 --field-selector status.phase=Failed -o name
+    exit 1
+  fi
+  RUNNING_COUNT=$(kubectl get pods -n convergence-tracker-0 --field-selector status.phase!=Succeeded -o name | wc -l)
+  if [ "$RUNNING_COUNT" -eq 0 ]; then
     echo "DONE"
     exit 0
   fi

--- a/kube-burner-workload/openshift/README.md
+++ b/kube-burner-workload/openshift/README.md
@@ -14,6 +14,11 @@
 `kube-burner init -m ./openshift/metrics.yml -c ./network-policy.yaml -u https://$(oc get route prometheus-k8s -n openshift-monitoring -o jsonpath="{.spec.host}") --log-level=debug --token=$(oc create token prometheus-k8s -n openshift-monitoring)`
 8. When the test finishes, metrics should be collected by the ES_SERVER
 
+## Finding the limit
+
+To automate finding the limit, [test_limit.sh](./test_limit.sh) script may be used.
+It can run multiple iterations increasing the number of network policies until test fails.
+It waits for full cleanup after every iteration to ensure the cluster is ready for the next one.
 
 ## Metrics and Dashboards
 

--- a/kube-burner-workload/openshift/convergence_tracker.yml
+++ b/kube-burner-workload/openshift/convergence_tracker.yml
@@ -12,10 +12,16 @@ spec:
       labelSelector:
         matchLabels:
           app: convergence-tracker
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
   volumes:
     - name: openvswitch
       hostPath:
         path: /var/run/openvswitch
+    - name: ovn
+      hostPath:
+        path: /var/run/ovn/
     - name: ovn-ic
       hostPath:
         path: /var/run/ovn-ic/
@@ -42,8 +48,10 @@ spec:
           mountPath: /var/run/openvswitch
         - name: host-var-log-ovs
           mountPath: /var/log/openvswitch
-        - name: ovn-ic
+        - name: ovn
           mountPath: /var/run/ovn
+        - name: ovn-ic
+          mountPath: /var/run/ovn-ic
         - name: pod-logs
           mountPath: /var/log/pods
       env:

--- a/kube-burner-workload/openshift/grafana_dash.json
+++ b/kube-burner-workload/openshift/grafana_dash.json
@@ -144,7 +144,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 10,
+        "w": 11,
         "x": 4,
         "y": 0
       },
@@ -314,7 +314,7 @@
       "gridPos": {
         "h": 3,
         "w": 3,
-        "x": 14,
+        "x": 15,
         "y": 0
       },
       "id": 541,
@@ -369,79 +369,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 17,
-        "y": 0
-      },
-      "id": 548,
-      "links": [],
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^labels\\.version$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.1",
-      "targets": [
-        {
-          "alias": "",
-          "bucketAggs": [],
-          "datasource": {
-            "type": "elasticsearch",
-            "uid": "$Datasource"
-          },
-          "hide": false,
-          "metrics": [
-            {
-              "id": "1",
-              "settings": {
-                "size": "500"
-              },
-              "type": "raw_data"
-            }
-          ],
-          "query": "uuid.keyword: $uuid AND metricName.keyword: \"clusterVersion\"",
-          "refId": "B",
-          "timeField": "timestamp"
-        }
-      ],
-      "title": "OCP version",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "elasticsearch",
-        "uid": "$Datasource"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -458,7 +385,7 @@
       "gridPos": {
         "h": 3,
         "w": 2,
-        "x": 20,
+        "x": 18,
         "y": 0
       },
       "id": 369,
@@ -475,7 +402,7 @@
           "fields": "/^labels\\.minor$/",
           "values": false
         },
-        "textMode": "value"
+        "textMode": "value_and_name"
       },
       "pluginVersion": "10.0.1",
       "targets": [
@@ -501,7 +428,7 @@
           "timeField": "timestamp"
         }
       ],
-      "title": "k8s minor",
+      "title": "k8s version",
       "type": "stat"
     },
     {
@@ -527,10 +454,10 @@
       "gridPos": {
         "h": 3,
         "w": 2,
-        "x": 22,
+        "x": 20,
         "y": 0
       },
-      "id": 371,
+      "id": 548,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -568,6 +495,77 @@
         }
       ],
       "title": "Etcd version",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "$Datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 22,
+        "y": 0
+      },
+      "id": 371,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^labels\\.version$/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.1",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "C3f6SSfnk"
+          },
+          "metrics": [
+            {
+              "$$hashKey": "object:31",
+              "field": "versi",
+              "id": "1",
+              "meta": {},
+              "settings": {
+                "size": 500
+              },
+              "type": "raw_data"
+            }
+          ],
+          "query": "uuid.keyword: $uuid AND metricName: \"clusterVersion\"",
+          "refId": "A",
+          "timeField": "timestamp"
+        }
+      ],
+      "title": "OCP version",
       "type": "stat"
     },
     {
@@ -840,7 +838,10 @@
               "_index": true,
               "_type": true,
               "highlight": true,
+              "jobConfig.beforeCleanup": true,
+              "jobConfig.churnCycles": true,
               "jobConfig.churnDelay": true,
+              "jobConfig.churnDeletionStrategy": true,
               "jobConfig.churnDuration": true,
               "jobConfig.churnPercent": true,
               "jobConfig.cleanup": true,
@@ -862,7 +863,6 @@
               "jobConfig.podWait": true,
               "jobConfig.preLoadImages": true,
               "jobConfig.preLoadPeriod": true,
-              "jobConfig.shutdownCondition": true,
               "jobConfig.verifyObjects": true,
               "jobConfig.waitFor": true,
               "jobConfig.waitForDeletion": true,
@@ -4164,7 +4164,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4291,7 +4292,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -4414,7 +4416,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4541,7 +4544,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4669,7 +4673,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4796,7 +4801,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4924,7 +4930,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5051,7 +5058,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5179,7 +5187,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5306,7 +5315,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5434,7 +5444,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5561,7 +5572,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -10503,7 +10515,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "network-policy-perf",
           "value": "network-policy-perf"
         },
@@ -10527,9 +10539,9 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "641ae22a-2a75-436e-bd8b-6f99451c7ee8",
-          "value": "641ae22a-2a75-436e-bd8b-6f99451c7ee8"
+          "selected": true,
+          "text": "8df1d686-01dd-4a32-bf55-10b90b76adbe",
+          "value": "8df1d686-01dd-4a32-bf55-10b90b76adbe"
         },
         "datasource": {
           "uid": "$Datasource"
@@ -10554,8 +10566,8 @@
       {
         "current": {
           "selected": false,
-          "text": "ci-ln-n6z2cik-72292-b2544-master-0",
-          "value": "ci-ln-n6z2cik-72292-b2544-master-0"
+          "text": "ci-ln-5qhjivt-72292-4z4xc-master-0",
+          "value": "ci-ln-5qhjivt-72292-4z4xc-master-0"
         },
         "datasource": {
           "uid": "$Datasource"
@@ -10580,8 +10592,8 @@
       {
         "current": {
           "selected": false,
-          "text": "ci-ln-n6z2cik-72292-b2544-worker-a-m8l9r",
-          "value": "ci-ln-n6z2cik-72292-b2544-worker-a-m8l9r"
+          "text": "ci-ln-5qhjivt-72292-4z4xc-worker-a-4r8xh",
+          "value": "ci-ln-5qhjivt-72292-4z4xc-worker-a-4r8xh"
         },
         "datasource": {
           "uid": "$Datasource"
@@ -10602,74 +10614,11 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
-      },
-      {
-        "current": {
-          "selected": true,
-          "text": [
-            "None"
-          ],
-          "value": [
-            ""
-          ]
-        },
-        "datasource": {
-          "uid": "$Datasource"
-        },
-        "definition": "{ \"find\" : \"terms\", \"field\": \"labels.node.keyword\",  \"query\": \"metricName.keyword: nodeRoles AND labels.role.keyword: infra AND uuid.keyword: $uuid\"}",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Infra nodes",
-        "multi": true,
-        "name": "infra",
-        "options": [],
-        "query": "{ \"find\" : \"terms\", \"field\": \"labels.node.keyword\",  \"query\": \"metricName.keyword: nodeRoles AND labels.role.keyword: infra AND uuid.keyword: $uuid\"}",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "P99",
-          "value": "P99"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Latency percentile",
-        "multi": false,
-        "name": "latencyPercentile",
-        "options": [
-          {
-            "selected": true,
-            "text": "P99",
-            "value": "P99"
-          },
-          {
-            "selected": false,
-            "text": "P95",
-            "value": "P95"
-          },
-          {
-            "selected": false,
-            "text": "P50",
-            "value": "P50"
-          }
-        ],
-        "query": "P99, P95, P50",
-        "queryValue": "",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -10687,8 +10636,8 @@
     ]
   },
   "timezone": "utc",
-  "title": "Kube-burner Report - Raw UUID",
+  "title": "Kube-burner Report - Raw UUID NetPol",
   "uid": "d3533f3e-79d6-42aa-9816-17d140c21d81",
-  "version": 38,
+  "version": 48,
   "weekStart": ""
 }

--- a/kube-burner-workload/openshift/metrics.yml
+++ b/kube-burner-workload/openshift/metrics.yml
@@ -85,7 +85,7 @@
   metricName: etcdVersion
   instant: true
 
-- query: cluster_version
+- query: cluster_version{type="completed"}
   metricName: clusterVersion
   instant: true
 

--- a/kube-burner-workload/openshift/test_limit.sh
+++ b/kube-burner-workload/openshift/test_limit.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+wait_cleanup () {
+  IFS=" " read -r -a POD_NAMES <<< "$(oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node -o jsonpath='{.items[*].metadata.name}')"
+#  POD_NAMES=($(oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node -o jsonpath='{.items[*].metadata.name}'))
+  FLOW_COUNT=0
+  for POD_NAME in "${POD_NAMES[@]}"; do
+    POD_FLOW_COUNT=$(oc exec -n openshift-ovn-kubernetes "$POD_NAME" -c ovn-controller -- curl -s "127.0.0.1:29105/metrics"|grep ovs_vswitchd_bridge_flows_total|grep br-int|rev|cut -f1 -d' '|rev)
+    if [ "$POD_FLOW_COUNT" -gt $FLOW_COUNT ]; then
+      FLOW_COUNT=$POD_FLOW_COUNT
+    fi
+  done
+  echo "$FLOW_COUNT"
+
+  while [ "$FLOW_COUNT" -ge 10000 ]; do
+    FLOW_COUNT=0
+    for POD_NAME in "${POD_NAMES[@]}"; do
+      POD_FLOW_COUNT=$(oc exec -n openshift-ovn-kubernetes "$POD_NAME" -c ovn-controller -- curl -s "127.0.0.1:29105/metrics"|grep ovs_vswitchd_bridge_flows_total|grep br-int|rev|cut -f1 -d' '|rev)
+      if [ "$POD_FLOW_COUNT" -gt $FLOW_COUNT ]; then
+        FLOW_COUNT=$POD_FLOW_COUNT
+      fi
+    done
+    echo "$FLOW_COUNT"
+    sleep 60
+  done
+  echo "shutdown succeeded"
+}
+
+pushd ..
+source ./env
+NETPOLS_PER_NAMESPACE=50
+STEP=50
+expectedStatus=0
+status=$expectedStatus
+while [ $status -eq $expectedStatus ]; do
+  echo "Network Policies per namespace=$NETPOLS_PER_NAMESPACE"
+  wait_cleanup
+  kube-burner init -m ./openshift/metrics.yml -c ./network-policy.yaml -u "https://$(oc get route prometheus-k8s -n openshift-monitoring -o jsonpath="{.spec.host}")" --token="$(oc create token prometheus-k8s -n openshift-monitoring)"
+  status=$?
+  if [ $STEP -eq 0 ]; then
+    echo "One iteration is finished"
+    exit 0
+  fi
+  NETPOLS_PER_NAMESPACE=$((NETPOLS_PER_NAMESPACE + STEP))
+done
+popd || exit


### PR DESCRIPTION
Add convergence tracker failure on timeout.
Update readme with cross-platform comparison notes.
Add script to find the limit for openshift. May be used as an example for other platforms.
Update openshift to work with non-ic 

Depends on https://github.com/kube-burner/kube-burner/pull/601 to work properly