### PR TITLE
Improve Calico metrics, fix relabeling rule.

### DIFF
--- a/kube-burner-workload/calico/metrics.yml
+++ b/kube-burner-workload/calico/metrics.yml
@@ -13,10 +13,10 @@
   metricName: APIRequestRate
 
 # Containers & pod metrics
-- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace="kube-system"}[2m]) * 100) by (container, pod, namespace, node)) > 0
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"kube-system|calico-system"}[2m]) * 100) by (container, pod, namespace, node)) > 0
   metricName: containerCPU
 
-- query: (sum(container_memory_rss{name!="",container!="POD",namespace="kube-system"}) by (container, pod, namespace, node)) > 0
+- query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"kube-system|calico-system"}) by (container, pod, namespace, node)) > 0
   metricName: containerMemory
 
 # Cluster metrics

--- a/kube-burner-workload/calico/monitoring.yaml
+++ b/kube-burner-workload/calico/monitoring.yaml
@@ -116,8 +116,9 @@ data:
         relabel_configs:
         - action: labelmap
           regex: __meta_kubernetes_node_label_(.+)
-        - target_label: __address__
-          replacement: localhost:9091
+        - source_labels: [__meta_kubernetes_node_address_InternalIP]
+          target_label: __address__
+          replacement: $1:9091
         - source_labels: [__meta_kubernetes_node_name]
           regex: (.+)
           target_label: __metrics_path__


### PR DESCRIPTION
Adjust Calico metrics:

* Collect metrics from either kube-system or calico-system namespaces.  The namespace depends on how Calico was installed.
* Fix Prometheus node relabeling rule.  It was creating one target per node but all the targets  used localhost for the address!